### PR TITLE
bug: s3에 업로드한 객체에 접근하지 못하는 오류를 해결한다.

### DIFF
--- a/app/api/common/process_image.py
+++ b/app/api/common/process_image.py
@@ -4,7 +4,7 @@ from app.aws.s3 import upload_file
 from app.core.config import settings
 
 
-def process_image(image: UploadFile = File(...)):
+async def process_image(image: UploadFile = File(...)):
     print("call process_image")
     # 파일 처리 부분
 
@@ -12,9 +12,9 @@ def process_image(image: UploadFile = File(...)):
     print(file_type)
 
     if file_type == "jpeg" or file_type == "jpg" or file_type == "png":
-        image_byte = image.read()
+        image_byte = await image.read()
         # 파일 s3에 업로드
-        obj_name = upload_file(image_byte, file_type)
+        obj_name = await upload_file(image_byte)
 
         image_url = f'https://{settings.s3_bucket_name}.s3.amazonaws.com/{obj_name}'
         return image_url

--- a/app/api/endpoint/router.py
+++ b/app/api/endpoint/router.py
@@ -9,6 +9,9 @@ from app.database.set_mysql import engine, get_db
 from app.api.common.get_cat_tower import check_location
 from app.api.common.process_image import process_image
 
+from app.aws.s3 import upload_file
+from app.core.config import settings
+
 
 import time
 
@@ -34,7 +37,7 @@ async def create_content(
         )
 
     # 이미지 처리
-    image_url = process_image(image)
+    image_url = await process_image(image)
 
     # 객체 처리
     cat_tower = check_location(lat, lon)

--- a/app/aws/s3.py
+++ b/app/aws/s3.py
@@ -21,7 +21,7 @@ def s3_connection():
         return s3
 
 
-def upload_file(image_byte: bytes, content_type: str = None) -> str:
+async def upload_file(image_byte: bytes) -> str:
     s3 = s3_connection()
     try:
         obj_name = uuid.uuid1()
@@ -30,7 +30,7 @@ def upload_file(image_byte: bytes, content_type: str = None) -> str:
             Key=obj_name.hex,
             Body=image_byte,
             ACL='public-read',
-            ContentType=f'image/{content_type}'
+            ContentType='image/jpeg'
         )
         print("uploaded file!")
 


### PR DESCRIPTION
- 파일을 read하는 비동기 처리로 인해  파일 타입이 정상적으로 처리되지 못하는 문제해결
- s3 업로드시 파일 타입을 일괄적으로 Image/jpeg로 지정해줌으로써 해결

- closed issue #67 